### PR TITLE
Update mage version contrain

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "yireo/magento2-replace-bundled",
   "description": "Replace bundled third party packages from Magento",
   "require": {
-    "magento/product-community-edition": ">=2.4.0 <2.4.1"
+    "magento/product-community-edition": ">=2.4.1 <2.4.2"
   },
   "replace": {
     "amzn/amazon-pay-and-login-magento-2-module": "*",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "yireo/magento2-replace-bundled",
   "description": "Replace bundled third party packages from Magento",
   "require": {
-    "magento/product-community-edition": ">=2.4.1 <2.4.2"
+    "magento/product-community-edition": ">=2.4.0 <2.4.2"
   },
   "replace": {
     "amzn/amazon-pay-and-login-magento-2-module": "*",


### PR DESCRIPTION
Uhm the version constraint is ok on the "magento-2.4.0" branch and basicly ok on the "magento-2.4.1" branch. The problem is: the magento-2.4.0 branch didn't get a new tag and according to semver the "magento-2.4.1" branch should get a major version bump.
As far as I can see you could either include mage2.4.0 into your 4.x.y version (with this PR) or skip the PR and update the versions on your side.