### PR TITLE
Remove vertex/module-tax-staging package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "vertex/module-tax": "*",
     "vertex/sdk": "*",
     "vertex/module-address-validation": "*",
+    "vertex/module-tax-staging": "*",
     "yotpo/magento2-module-yotpo-reviews": "*",
     "yotpo/magento2-module-yotpo-reviews-bundle": "*"
   }


### PR DESCRIPTION
Hi Jisse,

that's a module related to the Commerce Edition.
An error occurs during di:compile if the module is not replaced.

Cheers
Christian