### PR TITLE
Add temando/module-shipping-remover to dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     "paypal/module-braintree-reward": "*",
     "temando/module-shipping": "*",
     "temando/module-shipping-m2": "*",
+    "temando/module-shipping-remover": "*",
     "vertex/module-address-validation": "*",
     "vertex/module-tax": "*",
     "vertex/module-tax-staging": "*",


### PR DESCRIPTION
Fixes this error:

```
  Problem 1
    - magento/project-community-edition is present at version 2.4.6-p13 and cannot be modified by Composer
    - Root composer.json requires temando/module-shipping-remover == 1.0.0.0 -> satisfiable by temando/module-shipping-remover[1.0.0].
    - temando/module-shipping-remover[1.0.0] cannot be installed as that would require removing magento/project-community-edition[2.4.6-p13]. They both replace temando/module-shipping-m2 and thus cannot coexist.
 ```